### PR TITLE
Split up cluster-prepare task

### DIFF
--- a/ansible/main/playbooks/cluster-prepare.yaml
+++ b/ansible/main/playbooks/cluster-prepare.yaml
@@ -37,14 +37,22 @@
             filename: non-free
             update_cache: true
 
-        - name: Packages | Install
+        - name: Packages | Install ARM64
           ansible.builtin.apt:
-          ## Comment out intel-gpu-tools,intel-media-va-driver-non-free for rpis
-            name: apt-transport-https,ca-certificates,conntrack,curl,dirmngr,fish,gdisk,
-              gnupg,hdparm,htop,intel-gpu-tools,intel-media-va-driver-non-free,iptables,iputils-ping,ipvsadm,
-              libseccomp2,lm-sensors,neofetch,net-tools,nfs-common,nvme-cli,open-iscsi,parted,psmisc,python3,
-              python3-apt,python3-kubernetes,python3-yaml,smartmontools,socat,software-properties-common,unzip,
-              util-linux
+          - when: ansible_architecture == 'aarch64' or ansible_architecture == 'arm64'
+            name: apt-transport-https,ca-certificates,conntrack,curl,dirmngr,fish,gdisk,gnupg,hdparm,htop,
+              iptables,iputils-ping,ipvsadm,libseccomp2,lm-sensors,neofetch,net-tools,nfs-common,
+              nvme-cli,open-iscsi,parted,psmisc,python3,python3-apt,python3-kubernetes,python3-yaml,
+              smartmontools,socat,software-properties-common,unzip,util-linux
+            install_recommends: false
+
+        - name: Packages | Install AMD64
+          ansible.builtin.apt:
+          - when: ansible_architecture == 'x86_64' or ansible_architecture == 'amd64'
+            name: apt-transport-https,ca-certificates,conntrack,curl,dirmngr,fish,gdisk,gnupg,hdparm,htop,
+              intel-gpu-tools,intel-media-va-driver-non-free,iptables,iputils-ping,ipvsadm,libseccomp2,
+              lm-sensors,neofetch,net-tools,nfs-common,nvme-cli,open-iscsi,parted,psmisc,python3,python3-apt,
+              python3-kubernetes,python3-yaml,smartmontools,socat,software-properties-common,unzip,util-linux
             install_recommends: false
 
     - name: User Configuration


### PR DESCRIPTION
Currently, when doing a prepare, it will fail because the Raspberry Pi's lack the `intel-gpu-tools` and `intel-media-va-driver-non-free` packages. So I need to run it once, and then comment out those packages to continue.

This will allow it to install separate packages on my Raspberry Pis vs my worker x86 nodes.

Fixes #1337