### PR TITLE
Reconfigure Palworld to use new webhooks

### DIFF
--- a/kubernetes/teyvat/apps/games/palworld/app/externalsecret.yaml
+++ b/kubernetes/teyvat/apps/games/palworld/app/externalsecret.yaml
@@ -8,18 +8,10 @@ spec:
     template:
       type: Opaque
       data:
-        RCON_PASSWORD: "{{ .RCON_PASSWORD }}"
         SERVER_PASSWORD: "{{ .SERVER_PASSWORD }}"
         ADMIN_PASSWORD: "{{ .ADMIN_PASSWORD }}"
+        WEBHOOK_URL: "{{ .DISCORD_WEBHOOK }}"
   data:
-  - secretKey: RCON_PASSWORD
-    sourceRef:
-      storeRef:
-        name: bitwarden-fields
-        kind: ClusterSecretStore
-    remoteRef:
-      key: 14a164a2-87a1-42be-bb0e-b102004b0dab
-      property: rcon_password
   - secretKey: SERVER_PASSWORD
     sourceRef:
       storeRef:
@@ -36,3 +28,11 @@ spec:
     remoteRef:
       key: 14a164a2-87a1-42be-bb0e-b102004b0dab
       property: admin_password
+  - secretKey: DISCORD_WEBHOOK
+    sourceRef:
+      storeRef:
+        name: bitwarden-fields
+        kind: ClusterSecretStore
+    remoteRef:
+      key: 14a164a2-87a1-42be-bb0e-b102004b0dab
+      property: discord_webhook

--- a/kubernetes/teyvat/apps/games/palworld/app/helmrelease.yaml
+++ b/kubernetes/teyvat/apps/games/palworld/app/helmrelease.yaml
@@ -36,24 +36,27 @@ spec:
           main:
             image:
               repository: jammsen/palworld-dedicated-server
-              tag: 7afab27
+              tag: 3f555b9
             env:
+              ## Container Settings
               TZ: ${TIMEZONE}
               ALWAYS_UPDATE_ON_START: true
-              MAX_PLAYERS: 32
               MULTITHREAD_ENABLED: true
               COMMUNITY_SERVER: false
-              RCON_ENABLED: true
-              RCON_PORT: 25575
-              PUBLIC_PORT: 8211
-              PUBLIC_IP: pal.${SECRET_SECONDARY_DOMAIN}
-              SERVER_NAME: LDS-Palworld-Server
-              SERVER_DESCRIPTION: Palworld Server Running on Kubernetes
               BACKUP_ENABLED: false #volsync is backing up the PVC
               ## Server Gameplay Settings
-              BASE_CAMP_WORKER_MAXNUM: "20"
-              DEATH_PENALTY: "None"
+              DEATH_PENALTY: None
+              BASE_CAMP_WORKER_MAXNUM: 20
               PAL_EGG_DEFAULT_HATCHING_TIME: "2.000000" #Default for Normal Mode
+              ## Server Settings
+              SERVER_NAME: Platonically Pals
+              SERVER_DESCRIPTION: Smurf's Palworld. Come in, have a tako!
+              PUBLIC_PORT: &port 8211
+              RCON_ENABLED: true
+              RCON_PORT: &rcon-port 25575
+              PUBLIC_IP: pal.${SECRET_SECONDARY_DOMAIN}
+              ## Webhook Settings
+              WEBHOOK_ENABLED: true
             envFrom:
             - secretRef:
                 name: *app
@@ -83,12 +86,12 @@ spec:
             enabled: false
           game:
             protocol: UDP
-            port: 8211
+            port: *port
           rcon:
-            port: 25575
+            port: *rcon-port
     ingress:
       main:
-        enabled: true
+        enabled: false #nginx doesn't support non-https
         className: external
         annotations:
           external-dns.alpha.kubernetes.io/target: ipv4.${SECRET_SECONDARY_DOMAIN}

--- a/kubernetes/teyvat/apps/games/palworld/app/helmrelease.yaml
+++ b/kubernetes/teyvat/apps/games/palworld/app/helmrelease.yaml
@@ -35,8 +35,8 @@ spec:
         containers:
           main:
             image:
-              repository: jammsen/palworld-dedicated-server
-              tag: 3f555b9
+              repository: ghcr.io/jammsen/docker-palworld-dedicated-server
+              tag: master@sha256:e1b30e46fe1c5c77badc25ce4718f7f4f22a4575490fbf8f6613e3463e80c2a7
             env:
               ## Container Settings
               TZ: ${TIMEZONE}

--- a/kubernetes/teyvat/apps/games/palworld/tools/helmrelease.yaml
+++ b/kubernetes/teyvat/apps/games/palworld/tools/helmrelease.yaml
@@ -42,7 +42,7 @@ spec:
         containers:
           main:
             image:
-              repository: docker.io/outdead/rcon
+              repository: outdead/rcon
               tag: latest@sha256:8bf03935771ae6b44449eb8e74e1f4d249ead591e9c1e4e43539d33be1a3ac67
             command: ["./rcon"]
             args: [


### PR DESCRIPTION
Use the new webhook functionality.
Cleanup some of the vars, as I was already using the defaults.
Bump palworld docker image version