### PR TITLE
Migrate Arr stack

### DIFF
--- a/kubernetes/teyvat/apps/downloads/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/teyvat/apps/downloads/prowlarr/app/helmrelease.yaml
@@ -100,4 +100,6 @@ spec:
     persistence:
       config:
         enabled: true
-        existingClaim: *app
+        type: emptyDir
+      tmp:
+        type: emptyDir

--- a/kubernetes/teyvat/apps/downloads/prowlarr/app/kustomization.yaml
+++ b/kubernetes/teyvat/apps/downloads/prowlarr/app/kustomization.yaml
@@ -6,4 +6,3 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ../../../../templates/gatus/guarded
-  - ../../../../templates/volsync

--- a/kubernetes/teyvat/apps/downloads/prowlarr/ks.yaml
+++ b/kubernetes/teyvat/apps/downloads/prowlarr/ks.yaml
@@ -25,4 +25,3 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 2Gi

--- a/kubernetes/teyvat/apps/downloads/radarr/app/helmrelease.yaml
+++ b/kubernetes/teyvat/apps/downloads/radarr/app/helmrelease.yaml
@@ -120,6 +120,8 @@ spec:
       config:
         enabled: true
         existingClaim: *app
+      tmp:
+        type: emptyDir
       data:
         enabled: true
         type: nfs

--- a/kubernetes/teyvat/apps/downloads/radarr/app/kustomization.yaml
+++ b/kubernetes/teyvat/apps/downloads/radarr/app/kustomization.yaml
@@ -5,5 +5,5 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./pvc.yaml
   - ../../../../templates/gatus/guarded
-  - ../../../../templates/volsync

--- a/kubernetes/teyvat/apps/downloads/radarr/app/pvc.yaml
+++ b/kubernetes/teyvat/apps/downloads/radarr/app/pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: radarr
+spec:
+  accessModes: ["ReadWriteMany"]
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: ceph-filesystem

--- a/kubernetes/teyvat/apps/downloads/radarr/ks.yaml
+++ b/kubernetes/teyvat/apps/downloads/radarr/ks.yaml
@@ -25,4 +25,3 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 2Gi

--- a/kubernetes/teyvat/apps/downloads/readarr/app/helmrelease.yaml
+++ b/kubernetes/teyvat/apps/downloads/readarr/app/helmrelease.yaml
@@ -103,6 +103,8 @@ spec:
       config:
         enabled: true
         existingClaim: *app
+      tmp:
+        type: emptyDir
       data:
         enabled: true
         type: nfs

--- a/kubernetes/teyvat/apps/downloads/readarr/app/kustomization.yaml
+++ b/kubernetes/teyvat/apps/downloads/readarr/app/kustomization.yaml
@@ -5,5 +5,5 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./pvc.yaml
   - ../../../../templates/gatus/guarded
-  - ../../../../templates/volsync

--- a/kubernetes/teyvat/apps/downloads/readarr/app/pvc.yaml
+++ b/kubernetes/teyvat/apps/downloads/readarr/app/pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: readarr
+spec:
+  accessModes: ["ReadWriteMany"]
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: ceph-filesystem

--- a/kubernetes/teyvat/apps/downloads/readarr/ks.yaml
+++ b/kubernetes/teyvat/apps/downloads/readarr/ks.yaml
@@ -25,4 +25,3 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 2Gi

--- a/kubernetes/teyvat/apps/downloads/sonarr/app/helmrelease.yaml
+++ b/kubernetes/teyvat/apps/downloads/sonarr/app/helmrelease.yaml
@@ -120,6 +120,8 @@ spec:
       config:
         enabled: true
         existingClaim: *app
+      tmp:
+        type: emptyDir
       data:
         enabled: true
         type: nfs

--- a/kubernetes/teyvat/apps/downloads/sonarr/app/kustomization.yaml
+++ b/kubernetes/teyvat/apps/downloads/sonarr/app/kustomization.yaml
@@ -5,5 +5,5 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./pvc.yaml
   - ../../../../templates/gatus/guarded
-  - ../../../../templates/volsync

--- a/kubernetes/teyvat/apps/downloads/sonarr/app/pvc.yaml
+++ b/kubernetes/teyvat/apps/downloads/sonarr/app/pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sonarr
+spec:
+  accessModes: ["ReadWriteMany"]
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: ceph-filesystem

--- a/kubernetes/teyvat/apps/downloads/sonarr/ks.yaml
+++ b/kubernetes/teyvat/apps/downloads/sonarr/ks.yaml
@@ -25,4 +25,3 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 2Gi


### PR DESCRIPTION
With the migration to psql, the config pvc is no longer needed to store all configuration. for radarr/sonarr/prowlarr.
This is a test for readarr.